### PR TITLE
Respect Keep Zone System Loaded

### DIFF
--- a/TMG.Visum-XTMF1/Import/ImportZoneSystemFromVISUM.cs
+++ b/TMG.Visum-XTMF1/Import/ImportZoneSystemFromVISUM.cs
@@ -21,8 +21,6 @@ public sealed class ImportZoneSystemFromVISUM : IZoneSystem
     [SubModelInformation(Required = false, Description = "Load in a custom matrix to use for distances.")]
     public IDataSource<SparseTwinIndex<float>>? CustomDistances;
 
-
-
     public IZoneSystem? GiveData()
     {
         return this;
@@ -40,6 +38,10 @@ public sealed class ImportZoneSystemFromVISUM : IZoneSystem
 
     public void LoadData()
     {
+        if(Loaded && KeepLoaded)
+        {
+            return;
+        }
         ((Zone)_roamingZone).ZoneNumber = RoamingZoneNumber;
         LoadZones();
         LoadPlanningDistricts();


### PR DESCRIPTION
The current implementation will reload the zone system whenever LoadData is called
instead of just loading if the zones have not been previously loaded while the
KeepLoaded variable is true.  This change adds a check before loading.
